### PR TITLE
Add method to properly decode the Transaction Extra Field

### DIFF
--- a/bbot.py
+++ b/bbot.py
@@ -5,35 +5,42 @@ import json
 import time
 import random
 
-#discord stuff
+# discord stuff
+client = None
 token = open('tokenfile').read()
-client = discord.Client()
+
+if token:
+	if token == 'YOUR-TOKEN-HERE':
+		token = None
+	else:
+		client = discord.Client()
 
 
 tc = turtlecoin.TurtleCoind(host='public.turtlenode.io', port=11898)
 
 tclbh = tc.get_last_block_header()['result']
 
+
 def getstats(height):
 
 	tcgl = tc.get_last_block_header()['result']['block_header']
 
-	#height of the latest block
+	# height of the latest block
 	height = tcgl['height']
-	#hash of latest block
+	# hash of latest block
 	hash = tcgl['hash']
 	# whether atest block is orphan or not
 	orphan = tcgl['orphan_status']
 
-	#reward of the latest block
+	# reward of the latest block
 	reward = tcgl['reward']
 	breward = reward / 100
 
-	#wheter the time the block took to make is acceptable or not
+	# wheter the time the block took to make is acceptable or not
 	timex = tcgl['timestamp']
 	prevhash = tcgl['prev_hash']
-	glb = tc.getblock(prevhash)
-	time2 = glb['block']['timestamp']
+	glb = tc.get_block(prevhash)
+	time2 = glb['result']['block']['timestamp']
 	timed = timex - time2
 	rock = "388916188715155467"
 	pingrock = "<@" + rock + ">"
@@ -42,49 +49,48 @@ def getstats(height):
 		blocktime += "Block was too fast, {timed} seconds".format(timed=timed)
 		pingrock += ""
 	elif timed >= 90:
-		blocktime += f'Took too long, {timed} seconds.'
+		blocktime += 'Took too long, {timed} seconds.'.format(timed=timed)
 		pingrock += ""
 	else:
 		blocktime += "Took {timed} seconds to make, pretty nice".format(timed=timed)
 		pingrock = ""
 
-	#size of the block
-	bsize = tc.getblock(hash)
-	bsizes = bsize['block']['blockSize']
+	# size of the block
+	bsize = tc.get_block(hash)
+	bsizes = bsize['result']['block']['blockSize']
 
 	# number of transaction hashes in the block
-	txs = tc.getblock(hash)
-	ntxs = len(txs['block']['transactions'])
+	txs = tc.get_block(hash)
+	ntxs = len(txs['result']['block']['transactions'])
 
-	#each tx hash in the block
-	hashes = [x['hash'] for x in txs['block']['transactions']]
+	# each tx hash in the block
+	hashes = [x['hash'] for x in txs['result']['block']['transactions']]
 
 	# size of each tx
-	hahsizes = [z['size'] for z in txs['block']['transactions']]
+	hahsizes = [z['size'] for z in txs['result']['block']['transactions']]
 
-	#size of all the txs
-	txsize = txs['block']
+	# size of all the txs
+	txsize = txs['result']['block']
 	txsizes = txsize['transactionsCumulativeSize']
 
-
 	for hash in hashes:
-		#tx extra hash
-		teta = tc.gettransaction(hash)['tx']['extra']
-		#Decoded version of tx_extra:
+		# tx extra hash
+		teta = tc.get_transaction(hash)['result']['tx']['extra']
+		# Decoded version of tx_extra:
 		try:
 			deteta = bytes.fromhex(teta).decode('utf-8')
 		except UnicodeDecodeError:
 			print("deta oops")
-			#deteta = "unable to decode, probably nothing in there"
+			deteta = "unable to decode, probably nothing in there"
 
-	#size of tx extra		
-	txes =  bsizes-txsizes
+	# size of tx extra
+	txes = bsizes - txsizes
 
 	# % of txs in the block
-	txp = txsizes/bsizes * 100
+	txp = txsizes / bsizes * 100
 
 	# % of tx_extra in the block
-	txep = txes/bsizes * 100
+	txep = txes / bsizes * 100
 
 	return {'height': height, 'hash': hash, 'orphan': orphan, 'reward': breward, 'bsizes': bsizes, 'blocktime': blocktime, 'ntxs': ntxs, 'hashes': hashes, 'hahsizes': hahsizes, 'txsizes': txsizes, 'teta': teta, 'deteta': deteta, 'txes': txes, 'txp': txp, 'txep': txep, 'pingrock': pingrock}
 
@@ -110,22 +116,34 @@ def prettyPrintStats(blockstats):
 	msg += "Percentage of txs in the block: {} % \n".format(blockstats['txp'])
 	msg += "Percentage of tx_extra in the block: {} % ```".format(blockstats['txep'])
 
-	#msg += blockstats['pingrock']
-
-	return msg
+	# msg += blockstats['pingrock']
 	print(msg)
 
+	return msg
 
-@client.event
+
+class client_check(object):
+	def __init__(self, client):
+		self.client = client
+
+	def __call__(self, func):
+		if not self.client:
+			print("Cannot connect to Discord without a valid token. bot will attempt to print to console.")
+			# Return the function unchanged, not decorated with Discord API.
+			return func
+		return self.client.event(func)
+
+
+@client_check(client)
 async def on_ready():
 	print("connected")
-	height = tclbh['height']
+	height = tclbh['block_header']['height']
 	while True:
-		#prettyPrintStats(getstats(nheight))	
-		nheight = tc.getblockcount()['count']
+		nheight = tc.get_block_count()['result']['count']
 		if height != nheight:
 			prettyPrintStats(getstats(nheight))
-			await client.send_message(discord.Object(id='459931714471460864'), prettyPrintStats(getstats(nheight)))
+			if client:
+				await client.send_message(discord.Object(id='459931714471460864'), prettyPrintStats(getstats(nheight)))
 			print("val changed")
 			print(nheight)
 			print(height)
@@ -134,4 +152,13 @@ async def on_ready():
 		await asyncio.sleep(0.5)
 
 
-client.run(token)
+def start_local_event_loop():
+	loop = asyncio.get_event_loop()
+	loop.run_until_complete(on_ready())
+	loop.close()
+
+
+if client:
+	client.run(token)
+else:
+	start_local_event_loop()

--- a/bbot.py
+++ b/bbot.py
@@ -8,6 +8,8 @@ import random
 
 # discord stuff
 client = None
+tc = None
+tclbh = None
 token = open('tokenfile').read()
 
 if token:
@@ -17,9 +19,53 @@ if token:
 		client = discord.Client()
 
 
-tc = turtlecoin.TurtleCoind(host='public.turtlenode.io', port=11898)
+def connect_to_turtlecoind():
+	global tc
+	global tclbh
+	tc = turtlecoin.TurtleCoind(host='public.turtlenode.io', port=11898)
+	tclbh = tc.get_last_block_header()['result']
 
-tclbh = tc.get_last_block_header()['result']
+
+def decode_tx_extra(tx_extra_hex):
+	curr_index = 0
+	custom_data_arr = []
+	tx_extra_decoded = ''
+
+	while(curr_index < len(tx_extra_hex)):
+		# these are special cases. See https://cryptonote.org/cns/cns005.txt
+		if tx_extra_hex.startswith('00', curr_index):  # padding
+			# All zeroes from here. No need to report this. We're done!
+			curr_index = len(tx_extra_hex)
+		elif tx_extra_hex.startswith('01', curr_index):  # payment ID
+			curr_index += 2
+			payment_id = tx_extra_hex[curr_index:curr_index + 65]
+			curr_index += 65
+		elif tx_extra_hex.startswith('02', curr_index):  # extra nonce (custom data)
+			# next byte will specify size
+			subfield_size = int(tx_extra_hex[curr_index:curr_index + 2], 16)
+			curr_index += 2
+			data = tx_extra_hex[curr_index:curr_index + subfield_size]
+			custom_data_arr.append(data)
+			curr_index += subfield_size
+		else:
+			tx_extra_decoded += "Hm, something went wrong. I got an invalid subfield tag of {tag}\n".format(tag=tx_extra_hex[curr_index:])
+			curr_index += 2
+
+	tx_extra_decoded += "Payment ID: {}\n".format(payment_id)
+
+	for hash in custom_data_arr:
+		utf8_str = None
+		tx_extra_decoded += "Custom Data Hex: {}\n".format(hash)
+		# try decoding as utf-8 data as well
+		try:
+			utf8_str = bytearray.fromhex(hash).decode()
+		except ValueError as err:
+			pass
+
+		if utf8_str:
+			tx_extra_decoded += "Custom Data UTF-8: {}\n".format(utf8_str)
+
+	return tx_extra_decoded
 
 
 def getstats(height):
@@ -77,11 +123,7 @@ def getstats(height):
 		# tx extra hash
 		teta = tc.get_transaction(hash)['result']['tx']['extra']
 		# Decoded version of tx_extra:
-		try:
-			deteta = bytes.fromhex(teta).decode('utf-8')
-		except UnicodeDecodeError:
-			print("deta oops")
-			deteta = "unable to decode, probably nothing in there"
+		deteta = decode_tx_extra(teta)
 
 	# size of tx extra
 	txes = bsizes - txsizes
@@ -153,12 +195,15 @@ async def on_ready():
 
 
 def start_local_event_loop():
+	print("*** Starting local event loop with TurtleCoind ***")
 	loop = asyncio.get_event_loop()
 	loop.run_until_complete(on_ready())
 	loop.close()
 
 
 if __name__ == '__main__':
+	connect_to_turtlecoind()
+
 	if client:
 		client.run(token)
 	else:

--- a/bbot.py
+++ b/bbot.py
@@ -2,6 +2,7 @@ import discord
 import asyncio
 import turtlecoin
 import json
+import sys
 import time
 import random
 
@@ -22,7 +23,6 @@ tclbh = tc.get_last_block_header()['result']
 
 
 def getstats(height):
-
 	tcgl = tc.get_last_block_header()['result']['block_header']
 
 	# height of the latest block
@@ -158,7 +158,12 @@ def start_local_event_loop():
 	loop.close()
 
 
-if client:
-	client.run(token)
-else:
-	start_local_event_loop()
+if __name__ == '__main__':
+	if client:
+		client.run(token)
+	else:
+		try:
+			start_local_event_loop()
+		except KeyboardInterrupt as err:
+			print("\nShutdown requested. Exiting...")
+			sys.exit(0)

--- a/bbot.py
+++ b/bbot.py
@@ -38,17 +38,19 @@ def decode_tx_extra(tx_extra_hex):
 			curr_index = len(tx_extra_hex)
 		elif tx_extra_hex.startswith('01', curr_index):  # payment ID
 			curr_index += 2
-			payment_id = tx_extra_hex[curr_index:curr_index + 65]
-			curr_index += 65
+			payment_id = tx_extra_hex[curr_index:curr_index + 64]
+			curr_index += 64
 		elif tx_extra_hex.startswith('02', curr_index):  # extra nonce (custom data)
 			# next byte will specify size
-			subfield_size = int(tx_extra_hex[curr_index:curr_index + 2], 16)
+			curr_index += 2
+			subfield_size = 2 * int(tx_extra_hex[curr_index:curr_index + 2], 16)
 			curr_index += 2
 			data = tx_extra_hex[curr_index:curr_index + subfield_size]
+			curr_index += subfield_size
 			custom_data_arr.append(data)
 			curr_index += subfield_size
 		else:
-			tx_extra_decoded += "Hm, something went wrong. I got an invalid subfield tag of {tag}\n".format(tag=tx_extra_hex[curr_index:])
+			tx_extra_decoded += "Hm, something went wrong. I got an invalid subfield tag of {tag}\n".format(tag=tx_extra_hex[curr_index:curr_index + 2])
 			curr_index += 2
 
 	tx_extra_decoded += "Payment ID: {}\n".format(payment_id)

--- a/test_decode_tx_extra.py
+++ b/test_decode_tx_extra.py
@@ -1,0 +1,21 @@
+from bbot import decode_tx_extra
+
+
+known_hashes = [
+    '0134df59241f0676bd3395b08aa4b5432279d0b02bf7b33800a0c63b66a6250138',
+    '014230cfd7909d22bad63fb742331055974f2bd6697cc00b6ceaa44de0a7ad833102080000000006920e92'
+]
+
+known_results = [
+    'Payment ID: 34df59241f0676bd3395b08aa4b5432279d0b02bf7b33800a0c63b66a6250138\n',
+    'Payment ID: 4230cfd7909d22bad63fb742331055974f2bd6697cc00b6ceaa44de0a7ad8331\n'  # cont...
+    'Custom Data Hex: 0000000006920e92\n'
+]
+
+
+def test_known_hashes():
+    for i, hash in enumerate(known_hashes):
+        print('Testing known hash {}'.format(i))
+        result = decode_tx_extra(hash)
+        print(result)
+        assert result == known_results[i]


### PR DESCRIPTION
## Status
TESTING, review comments ok

## Summary
In addition to creating `decode_tx_extra()` and logic as per the whitepaper, I have also done a little restructuring in the file to support offline testing (not connected to Discord server). It takes effect if you don't have a Token set. This way, I was able to just print results to the command line.

My test file is isolated further and does not use Turtlecoind either.

**_IMPORTANT_:** The changes include APIs calls to the _latest_ (development) version of `turtlecoin` which is not released yet. I have installed that module from source. That is why there is some extra churn in the diff. I might be able to revert some of the changes if needed.

## Changes
- Added `decode_tx_extra()` method, which accepts a tx extra hex string and returns a string of decoded data. This keeps a marker (`curr_index`) on the hex string and moves along it checking for subfields. Currently it tries to decode custom data in UTF-8 format. It may be possible to add ascii as a fallback.
- Turtlecoind connection is now established in `connect_to_turtlecoind()`. This only occurs if the file is being run (as opposed to imported), i.e. `if __name__ == '__main__':`
- Updated to latest `turtlecoin` code. Notice APIs are now snake_case and return a `['result']` dictionary.
- Fixed a few minor lint issues.